### PR TITLE
Add link to phabricator task,diff, paste, file  and commit

### DIFF
--- a/PhabricatorIntegrationApp.ts
+++ b/PhabricatorIntegrationApp.ts
@@ -7,15 +7,52 @@ import {
     IModify,
     IPersistence,
     IRead,
+    IMessageBuilder
 } from '@rocket.chat/apps-engine/definition/accessors';
 import { App } from '@rocket.chat/apps-engine/definition/App';
-import { IMessage, IMessageAttachment, IPostMessageSent } from '@rocket.chat/apps-engine/definition/messages';
+import { IMessage,IPreMessageSentModify, IMessageAttachment, IPostMessageSent } from '@rocket.chat/apps-engine/definition/messages';
 import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
 import { SettingType } from '@rocket.chat/apps-engine/definition/settings';
 
-export class PhabricatorIntegrationApp extends App implements IPostMessageSent {
+export class PhabricatorIntegrationApp extends App implements IPreMessageSentModify, IPostMessageSent{
     constructor(info: IAppInfo, logger: ILogger, accessors: IAppAccessors) {
         super(info, logger, accessors);
+    }
+
+    //Suport Phabricator Task, Differential ,File,Paste  e.g : T1234, D1234, F1234
+    private phabricator_matcher : RegExp = /[TDFP]\d{2,}\b/gm 
+    //Suport Phabricator commit hash for at least 12  characters longs 
+    private commit_matcher  : RegExp = /\b(rB)?([a-f0-9]{11,40})\b/gm;
+
+    private isTextMatching(text:string,matcher :RegExp){
+        return matcher.test(text)
+    }
+
+    public async checkPreMessageSentModify(message: IMessage, read: IRead, http: IHttp): Promise<boolean> {
+        if (typeof message.text !== 'string') {
+            return false;
+        }
+        let result:boolean = false
+
+        result = result || this.isTextMatching(message.text, this.phabricator_matcher)
+        result = result|| this.isTextMatching(message.text, this.commit_matcher)
+
+        return result;
+    }
+    public async executePreMessageSentModify(message: IMessage, builder: IMessageBuilder, read: IRead, http: IHttp, persistence: IPersistence): Promise<IMessage> {
+        const server = await read.getEnvironmentReader().getSettings().getValueById('phabricator_server');
+
+        let text = message.text || '';
+        
+        //replace text with corresponding markdown
+        text = text.replace(this.phabricator_matcher, `[$&](${server}/$&)`);
+        text = text.replace(this.commit_matcher, `[$&](${server}/rB$2)`);
+
+        /*  How to remove default attachements? 
+        let attachements :Array<IMessageAttachment> = [];
+        builder.setAttachments(attachements) 
+        */
+        return builder.setText(text).getMessage();
     }
 
     public async checkPostMessageSent(message: IMessage, read: IRead, http: IHttp): Promise<boolean> {
@@ -35,7 +72,7 @@ export class PhabricatorIntegrationApp extends App implements IPostMessageSent {
         let attachments : Array<IMessageAttachment> = [];
         const regex = /\bT([0-9]+)\b/g;
         let match = regex.exec(text);
-
+        let memoization_task = {}
         while (match != null) {
             let link = await http.get(`${server}/api/maniphest.info`,
             {
@@ -44,15 +81,20 @@ export class PhabricatorIntegrationApp extends App implements IPostMessageSent {
                     'task_id': match[1],
                 },
             });
-
-            attachments.push({
+            let attachment = {
                 title: {
-                    value: link.data.result.title,
+                    value: `${link.data.result.objectName} ${link.data.result.title}`,
                     link: link.data.result.uri,
                 },
                 text: link.data.result.description,
                 collapsed: true,
-            });
+            };
+            if (!(link.data.result.objectName in memoization_task))
+            {
+                console.log(attachments);
+                attachments.push(attachment);
+                memoization_task[link.data.result.objectName] = attachment
+            }
 
             match = regex.exec(text);
         }
@@ -67,7 +109,7 @@ export class PhabricatorIntegrationApp extends App implements IPostMessageSent {
         await configuration.settings.provideSetting({
             id: 'phabricator_server',
             type: SettingType.STRING,
-            packageValue: '',
+            packageValue: 'https://developer.blender.org',
             required: true,
             public: false,
             i18nLabel: 'phabricator_serverurl',
@@ -77,7 +119,7 @@ export class PhabricatorIntegrationApp extends App implements IPostMessageSent {
         await configuration.settings.provideSetting({
             id: 'phabricator_apikey',
             type: SettingType.STRING,
-            packageValue: '',
+            packageValue: 'api-ssb3tye4uhqpq6336z564qb25h3d',
             required: true,
             public: false,
             i18nLabel: 'phabricator_apikey',


### PR DESCRIPTION

Added link to phabricator task, diff, paste, file and commit by modify message to use markdown
Added memoization to avoid duplication of attachments e.g if T4545 was named two time in the message there will be two attachment for this task

The problem I run into is that rocket chat add default attachment to link and duplicate the added one.
it's not an issue if Rocket chat link preview is disable but if @scaredyfish  if you have an idea how to make it work for every configuration